### PR TITLE
Fixed typo on image optimization guide

### DIFF
--- a/guides/image_optimization.md
+++ b/guides/image_optimization.md
@@ -24,8 +24,8 @@ The image optimizer will only return an optimized image for mobile browsers. Des
 
 Quality:
 
-https://opt.moovweb.net?quality=30&img=https://opt.moovweb.net/?img=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2F6%2F68%2FGrass_dsc08672-nevit.jpg%2F2560px-Grass_dsc08672-nevit.jpg
+https://opt.moovweb.net?quality=30&img=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2F6%2F68%2FGrass_dsc08672-nevit.jpg%2F2560px-Grass_dsc08672-nevit.jpg
 
 Height:
 
-https://opt.moovweb.net?height=300&img=https://opt.moovweb.net/?img=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2F6%2F68%2FGrass_dsc08672-nevit.jpg%2F2560px-Grass_dsc08672-nevit.jpg
+https://opt.moovweb.net?height=300&img=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2F6%2F68%2FGrass_dsc08672-nevit.jpg%2F2560px-Grass_dsc08672-nevit.jpg


### PR DESCRIPTION
Example URLs have `img` query parameter twice.