### PR TITLE
fix for csr generation issue

### DIFF
--- a/guides/production.md
+++ b/guides/production.md
@@ -103,8 +103,9 @@ To create CSR and private key do the following:
 ```properties
 [req]
 default_bits=2048
+distinguished_name = req_distinguished_name
 
-[distinguished_name]
+[req_distinguished_name]
 countryName=Country Name (2 letter code)
 countryName_default=US
 stateOrProvinceName=State or Province Name (full name)


### PR DESCRIPTION
Fix for this error:

```
% openssl req -out moovweb-xdn.csr -newkey rsa:2048 -nodes -keyout moovweb-xdn.key -config moovweb-xdn.conf -batch
Generating a 2048 bit RSA private key
..................................................................+++
..............................+++
writing new private key to 'moovweb-xdn.key'
-----
unable to find 'distinguished_name' in config
problems making Certificate Request
4636196460:error:0EFFF06C:configuration file routines:CRYPTO_internal:no value:/AppleInternal/BuildRoot/Library/Caches/com.apple.xbs/Sources/libressl/libressl-47.140.1/libressl-2.8/crypto/conf/conf_lib.c:322:group=req name=distinguished_name
```