### PR TITLE
Update gatsby.md

### DIFF
--- a/guides/gatsby.md
+++ b/guides/gatsby.md
@@ -19,7 +19,7 @@ npm install -g gatsby-cli
 gatsby new gatsby-site https://github.com/gatsbyjs/gatsby-starter-hello-world
 ```
 
-You should now have a working Gatsby site. Run `gatsby serve` to see the application running on `localhost:8000`.
+You should now have a working Gatsby site. Run `gatsby develop` to see the application running on `localhost:8000`.
 
 To deploy your Gatsby on Moovweb XDN:
 


### PR DESCRIPTION
@molebox pointed out we should instruct users to use `gatsby develop` instead of `gatsby serve` to avoid issues the first time through the guide

https://forum.moovweb.com/t/skip-global-xdn-npm-install/140/3

https://github.com/gatsbyjs/gatsby/issues/16092