### PR TITLE
remove team from xdn deploy

### DIFF
--- a/guides/vsf.md
+++ b/guides/vsf.md
@@ -57,5 +57,5 @@ xdn dev --cache
 To build and deploy your app to the XDN, run the following from the root directory of your app:
 
 ```
-xdn deploy <team> # where team is the name of the XDN team to which the app should be deployed.
+xdn deploy 
 ```


### PR DESCRIPTION
next guide, which I consider to be canonical does not do this and it just adds more complexity